### PR TITLE
Mark 'Generated' directory as generated code

### DIFF
--- a/V4API/.gitattributes
+++ b/V4API/.gitattributes
@@ -1,0 +1,1 @@
+Generated/** linguist-generated=true


### PR DESCRIPTION
diff が見にくくなってしまうので `.gitattributes` を追加して `Generated/** linguist-generated=true` を指定するようにした